### PR TITLE
Allow click on readonly or disabled mode

### DIFF
--- a/src/component/bar-rating.component.ts
+++ b/src/component/bar-rating.component.ts
@@ -116,9 +116,11 @@ export class BarRatingComponent implements OnInit, OnChanges, ControlValueAccess
 
   private handleClick(e, value) {
     /** (NOT TESTED) Remove 300ms click delay on touch devices */
-    e.preventDefault();
-    e.stopPropagation();
-    this.update(value + 1);
+    if (!this.disabled && !this.readOnly) {
+      e.preventDefault();
+      e.stopPropagation();
+      this.update(value + 1);
+    }
   }
 
   private handleEnter(index) {


### PR DESCRIPTION
Right now when you try to click on the ngx-bar-rating element, the default action is prevented. 

It should only be disabled when it's not in readonly or disabled mode -- this allows users to hook onto the click event when the element is clicked during those modes. 

#29 